### PR TITLE
Added visibility of extensions into main package.

### DIFF
--- a/wurst/Lodash.wurst
+++ b/wurst/Lodash.wurst
@@ -3,6 +3,9 @@ import LinkedList
 import HashMap
 import HashSet
 
+// Make all extensions visible in the primary package.
+import public initlater LodashExtensions
+
 /**
  * Ownable object
  *

--- a/wurst/LodashTests.wurst
+++ b/wurst/LodashTests.wurst
@@ -2,7 +2,6 @@ package LodashTests
 import LinkedList
 import HashMap
 import Lodash
-import LodashExtensions
 
 var initialOwnableCount = 0
 


### PR DESCRIPTION
A lot of users will import both `Lodash` and `LodashExtensions` so that they can create an owned data structure and then call methods on it. This simplifies the process by allowing users to gain full functionality just by importing `Lodash`.