### PR TITLE
Added joining for list of strings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Functional Programming Utilities for [WurstScript](https://wurstlang.org/) inspi
     - [`groupBy`](#groupBy)
     - [`indexBy`](#indexBy)
     - [`intersection`](#intersection)
+    - [`join`](#join)
     - [`keys`](#keys)
     - [`length`](#length)
     - [`map`](#map)
@@ -421,6 +422,18 @@ The predicate is invoked with one argument: (value). Example:
 ```typescript
 asList(1, 2, 3, 4, 5).any(x -> x < 2) // => true
 asList(1, 2, 3, 4, 5).any(x -> x > 9) // => false
+```
+
+#### `join`
+
+```typescript
+function LinkedList<string>.join(string separator) returns string
+```
+
+Concatenates the strings in a list using a given separator. Example:
+
+```typescript
+asList("a", "b", "c").join(", ") // => "a, b, c"
 ```
 
 #### `keys`

--- a/wurst/Lodash.wurst
+++ b/wurst/Lodash.wurst
@@ -653,6 +653,14 @@ public function max(LinkedList<real> list) returns real
     return foldl(REAL_MAX, (value, elem) -> min(value, elem), list)
 
 /**
+ * Concatenates the values in a list using a separator and maybe frees it.
+ */
+ public function join(LinkedList<string> list, string separator) returns string
+    let result = list.joinBy(separator)
+    list.maybeFree()
+    return result
+
+/**
  * Gets the length of list and maybe frees it
  */
 public function length<T>(LinkedList<T> list) returns int

--- a/wurst/LodashExtensions.wurst
+++ b/wurst/LodashExtensions.wurst
@@ -161,6 +161,12 @@ public function LinkedList<real>.min() returns real
     return min(this)
 
 /**
+ * Concatenates the values in a list using a separator and maybe frees it.
+ */
+public function LinkedList<string>.join(string separator) returns string
+    return join(this, separator)
+
+/**
  * Gets the length of list and maybe frees it
  */
 public function LinkedList<T>.length<T>() returns int

--- a/wurst/LodashTests.wurst
+++ b/wurst/LodashTests.wurst
@@ -316,6 +316,11 @@ function min()
     asList(1.1, 2.2, 3.3).min().assertEquals(1.1)
 
 @Test
+function join()
+    // join(LinkedList<string> list, string separator) returns string
+    asList("a", "b", "c").join(", ").assertEquals("a, b, c")
+
+@Test
 function length()
     // length<T>(LinkedList<T> list) returns int
 


### PR DESCRIPTION
I omitted a default value as that would conflict with the standard library `.join` method. I also think it's more trouble than it's worth - Lodash uses "," which is not what I would have expected, so this way it forces people to write clearer code. 