### PR TITLE
Added .countBy() to count elem matching predicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Functional Programming Utilities for [WurstScript](https://wurstlang.org/) inspi
     - [`uniqBy`](#uniqBy)
     - [`values`](#values)
     - [`zipObject`](#zipObject)
+    - [`countBy`](#countBy)
 
 ## `package Lodash`
 
@@ -973,4 +974,17 @@ Returns the last element matching the predicate function. Example:
 ```typescript
 asList(pair(1, "a"), pair(2, "b"), pair(3, "c"), pair(2, "d")).findLast(x -> x.a == 2)
 // => pair(2, "d")
+```
+
+#### `countBy`
+
+```typescript
+function LinkedList<T>.countBy<T>(Predicate<T> predicate) returns int
+```
+
+Counts the elements returning truthy for all elements of collection.
+The predicate is invoked with one argument: (value). Example:
+
+```typescript
+asList(1, 1, 1, 4, 5, 6).countBy(x -> x < 5) // => 4
 ```

--- a/wurst/Lodash.wurst
+++ b/wurst/Lodash.wurst
@@ -1039,3 +1039,18 @@ public function findLast<T>(LinkedList<T> list, Predicate<T> func) returns T
     list.maybeFree()
     func.maybeFree()
     return null
+
+/**
+ * Counts the elements returning truthy for all elements of collection.
+ * The predicate is invoked with one argument: (value).
+ */
+public function countBy<T>(Predicate<T> predicate, LinkedList<T> list) returns int
+    var count = 0
+    let iter = list.iterator()
+    for elem from iter
+        if predicate.call(elem)
+            count++
+    iter.close()
+    list.maybeFree()
+    predicate.maybeFree()
+    return count

--- a/wurst/LodashExtensions.wurst
+++ b/wurst/LodashExtensions.wurst
@@ -331,3 +331,10 @@ public function LinkedList<T>.find<T>(Predicate<T> func) returns T
  */
 public function LinkedList<T>.findLast<T>(Predicate<T> func) returns T
     return findLast(this, func)
+
+/**
+ * Counts the elements returning truthy for all elements of collection.
+ * The predicate is invoked with one argument: (value).
+ */
+public function LinkedList<T>.countBy<T>(Predicate<T> predicate) returns int
+    return countBy(predicate, this)


### PR DESCRIPTION
I encountered the following need.
Not sure if that follows the Lodash idiom.